### PR TITLE
fix #includes for case-sensitive filesystems/OS

### DIFF
--- a/firmware/src/BSP/calibration.c
+++ b/firmware/src/BSP/calibration.c
@@ -22,7 +22,7 @@
  
 #include "calibration.h"
 #include "nonvolatile.h"
-#include "USART.h"
+#include "usart.h"
 
 extern volatile int64_t currentLocation;
 

--- a/firmware/src/BSP/nonvolatile.c
+++ b/firmware/src/BSP/nonvolatile.c
@@ -21,7 +21,7 @@
  */
 
 #include "nonvolatile.h"
-#include "USART.h"
+#include "usart.h"
 
 extern volatile MotorParams_t motorParams;
 extern volatile SystemParams_t systemParams;

--- a/firmware/src/BSP/usart.c
+++ b/firmware/src/BSP/usart.c
@@ -20,7 +20,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#include "USART.h"
+#include "usart.h"
 
 ///**
 //	* @brief   USART


### PR DESCRIPTION
This fixes some #includes that break on all filesystems/OS that are case-sensitive with filenames.