### PR TITLE
move command scaling as MISFITTECH code suggests

### DIFF
--- a/firmware/src/BSP/A4950.c
+++ b/firmware/src/BSP/A4950.c
@@ -117,6 +117,10 @@ int32_t A4950_move(int32_t stepAngle, uint32_t mA)
 	{
 		cos = -cos;
 	}
+	//scale sine result by current(mA)
+	vrefSin=((int32_t)mA*(int64_t)abs(sin))/SINE_MAX;
+	//scale cosine result by current(mA)
+	vrefCos=((int32_t)mA*(int64_t)abs(cos))/SINE_MAX;
 
 	//convert value into DAC scaled to 3300mA max
 	vrefSin = (uint16_t)(mA * fastAbs(sin) / 3300);


### PR DESCRIPTION
This is a pullrequest for [this issue](https://github.com/makerbase-mks/MKS-SERVO42B/issues/8).
It looks like a part of the original MISFITTECH code was not included (see diff).
The original code scales the correction signal first by 511 (max sinewave amplitude?) and afterwards by 3300 (max output current of the PWM?). The MKS code only divides by 3300 that should result in much harder corrections and maybe overshoots and oscillations around steady state.

With the additional scaling I get less vibration around 0 in my setup. Also it seems to behave a bit smoother.
Please verify for yourself, if this improves the behavior. I assume, it can also be tuned similarly via the PID values but quantiziation errors might be a limit for this route.


